### PR TITLE
Fixed mulit-detector summing and updated data urls

### DIFF
--- a/src/gdt/data/cgro-batse.urls
+++ b/src/gdt/data/cgro-batse.urls
@@ -1,6 +1,6 @@
-ftp://heasarc.gsfc.nasa.gov/compton/data/batse/trigger/00001_00200/00105_burst/cont_bfits_3_105.fits.gz
-ftp://heasarc.gsfc.nasa.gov/compton/data/batse/trigger/00001_00200/00105_burst/cont_drm_3_105.fits.gz
-ftp://heasarc.gsfc.nasa.gov/compton/data/batse/trigger/00001_00200/00105_burst/discsc_drm_105.fits.gz
-ftp://heasarc.gsfc.nasa.gov/compton/data/batse/trigger/00001_00200/00105_burst/tte_list_105.fits.gz
-ftp://heasarc.gsfc.nasa.gov/compton/data/batse/daily/08001_09000/08361_08400/dds08362/cont_08362.fits.gz 
-ftp://heasarc.gsfc.nasa.gov/compton/data/batse/daily/08001_09000/08361_08400/dds08362/discla_08362.fits.gz
+https://heasarc.gsfc.nasa.gov/FTP/compton/data/batse/trigger/00001_00200/00105_burst/cont_bfits_3_105.fits.gz
+https://heasarc.gsfc.nasa.gov/FTP/compton/data/batse/trigger/00001_00200/00105_burst/cont_drm_3_105.fits.gz
+https://heasarc.gsfc.nasa.gov/FTP/compton/data/batse/trigger/00001_00200/00105_burst/discsc_drm_105.fits.gz
+https://heasarc.gsfc.nasa.gov/FTP/compton/data/batse/trigger/00001_00200/00105_burst/tte_list_105.fits.gz
+https://heasarc.gsfc.nasa.gov/FTP/compton/data/batse/daily/08001_09000/08361_08400/dds08362/cont_08362.fits.gz 
+https://heasarc.gsfc.nasa.gov/FTP/compton/data/batse/daily/08001_09000/08361_08400/dds08362/discla_08362.fits.gz

--- a/src/gdt/missions/cgro/batse/phaii.py
+++ b/src/gdt/missions/cgro/batse/phaii.py
@@ -554,7 +554,7 @@ class BatsePhaiiMulti(FitsFileContextManager, SpacecraftFrameModelMixin):
 
         ecalibs = [phaii.ecalib for phaii in phaiis]
         ecalib_sum = BatseEnergyCalib.combine_detectors(ecalibs)
-        e_edges = ecalib_sum.edges_over_timespan(0, self._tstart[0], 
+        e_edges = ecalib_sum.edges_over_timespan(det_var_list[0], self._tstart[0], 
                                                     self._tstop[-1])
         
         data = BatseTimeEnergyBins(counts, phaiis[0].data.tstart, 


### PR DESCRIPTION
As noted in [this issue. ](https://github.com/USRA-STI/gdt-cgro/issues/3#issue-3091181674)

Summing of detectors would fail if detector 0 was not specified due to detector 0 being hardcoded into the edges_over_timespan function call arguments. This has now been changed to the first detector in the list of detectors.

I have also changed the data urls to allow me to run the unit tests. It is possible the original ones are suitable and should not be changed but for me it did not appear to work with the ftp urls.